### PR TITLE
Fix problem with all matching outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,17 @@ If the entity is:
       not_letting_itself_be_detroyed?: true
     }
 
-#### To get the first matching result
+#### To get the first matching result output
 
     RoboticsRule.apply(entity) #=> true
 
-#### To get all matching results
+#### To get all matching result outputs
 
-    RoboticsRule.all(entity) #=> [true]
+    RoboticsRule.all(entity) #=> [true, false]
+    
+Note that `false` is the result outcome coming out from `default(false)` on top level, which is also called `root node`. The `root` node does not have any condition and hence
+it is considered to be matching. This means, by consequence, that its result (`default(false)`) is included in the list of matching result outputs which `#all(entity)` above
+returns.
 
 #### To get the trace of all nodes
 

--- a/lib/rulezilla/tree.rb
+++ b/lib/rulezilla/tree.rb
@@ -12,6 +12,8 @@ module Rulezilla
       @current_node = is_root? ? @root_node : @current_node.parent
     end
 
+    # Returns all the result outcomes of all the matching nodes.
+    #
     def find_all(record, node=@root_node)
       array = []
       if node.applies?(record)
@@ -21,7 +23,7 @@ module Rulezilla
 
         return node.has_result? ? array + [node] : array
       end
-      return array
+      array
     end
 
     def trace(record, node=@root_node)

--- a/spec/features/rulezilla_dsl_framework.feature
+++ b/spec/features/rulezilla_dsl_framework.feature
@@ -185,6 +185,30 @@ Scenario: To get all matching outcomes from a rule
     """
   Then all the matching outcomes are "B, C, D, F"
 
+Scenario: To get all matching outcomes from a rule - scenario 2
+  Given the rule is:
+  """
+    group :may_not_injure_human do
+      condition { not_injure_human? }
+
+      group :obey_human do
+        condition { do_as_human_told? }
+        result(true)
+
+        define :protect_its_own_existence do
+          condition { in_danger? && not_letting_itself_be_detroyed? }
+          result(true)
+        end
+      end
+    end
+
+    default(false)
+  """
+  When the record has attribute "not_injure_human?" and returns "true"
+  When the record has attribute "do_as_human_told?" and returns "true"
+  When the record has attribute "in_dangert?" and returns "true"
+  When the record has attribute "not_letting_itself_be_detroyed?" and returns "true"
+  Then all the matching outcomes are "true"
 
 Scenario: Support Module
   Given the rule class name is "FruitRule"

--- a/spec/features/rulezilla_dsl_framework.feature
+++ b/spec/features/rulezilla_dsl_framework.feature
@@ -185,7 +185,7 @@ Scenario: To get all matching outcomes from a rule
     """
   Then all the matching outcomes are "B, C, D, F"
 
-Scenario: To get all matching outcomes from a rule - scenario 2
+Scenario: To get all matching outcomes from a rule with root node default result
   Given the rule is:
   """
     group :may_not_injure_human do
@@ -203,6 +203,29 @@ Scenario: To get all matching outcomes from a rule - scenario 2
     end
 
     default(false)
+  """
+  When the record has attribute "not_injure_human?" and returns "true"
+  When the record has attribute "do_as_human_told?" and returns "true"
+  When the record has attribute "in_dangert?" and returns "true"
+  When the record has attribute "not_letting_itself_be_detroyed?" and returns "true"
+  Then all the matching outcomes are "true, false"
+
+Scenario: To get all matching outcomes from a rule without root node default result
+  Given the rule is:
+  """
+    group :may_not_injure_human do
+      condition { not_injure_human? }
+
+      group :obey_human do
+        condition { do_as_human_told? }
+        result(true)
+
+        define :protect_its_own_existence do
+          condition { in_danger? && not_letting_itself_be_detroyed? }
+          result(true)
+        end
+      end
+    end
   """
   When the record has attribute "not_injure_human?" and returns "true"
   When the record has attribute "do_as_human_told?" and returns "true"

--- a/spec/features/step_definitions/rulezilla_dsl_framework_steps.rb
+++ b/spec/features/step_definitions/rulezilla_dsl_framework_steps.rb
@@ -90,7 +90,7 @@ step 'all the outcomes are :outcomes' do |outcomes|
 end
 
 step 'all the matching outcomes are :outcomes' do |outcomes|
-  outcomes = outcomes.split(',').map(&:strip)
+  outcomes = outcomes.split(',').map(&:strip).map {|o| o == 'true' ? true : (o == 'false' ? false : o)}
   expect(@rule_klass.all(@record)).to match_array outcomes
 end
 


### PR DESCRIPTION
Refs #13 
Does not close the issue. It only tries to prove that there is a bug here.
Will try to come back with a fix later on.

**Update:** I believe that the problem is on README.md file and the example
should say that the result outputs are [true, false] and not just [true]. 
This is because the root node has the 'default(false)' as result, and root
node is unconditional, which means it matches anyway.

So, I have introduced one more Scenario, one with `default(false)` on root node and one without. 

In summary, there is not any bug. At least as far as I can tell, but this PR adds some more Scenarios
and corrects the README.md file example and makes clear how the `root` node works.

I believe that the issue #13 can be closed.

**Note:** Github reports that `All checks have passed` and in particular `semaphoreci` shows that the build has passed. Does it really run the tests? Because on my end, the Scenario committed does not pass.