### PR TITLE
upgrade versioning logic for dependabot

### DIFF
--- a/lib/rulezilla/version.rb
+++ b/lib/rulezilla/version.rb
@@ -1,3 +1,7 @@
 module Rulezilla
-  VERSION = '0.2.0'
+  VERSION = '0.2.0' # rubocop:disable Style/MutableConstant
+
+  # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
+  VERSION << '.' << ENV['GEM_PRE_RELEASE'].strip \
+  unless ENV.fetch('GEM_PRE_RELEASE', '').strip.empty?
 end

--- a/rulezilla.gemspec
+++ b/rulezilla.gemspec
@@ -2,12 +2,6 @@ $:.push File.expand_path("../lib", __FILE__)
 require 'rulezilla/version'
 
 Gem::Specification.new do |gem|
-  gem_version = if ENV['GEM_PRE_RELEASE'].nil? || ENV['GEM_PRE_RELEASE'].empty?
-                  Rulezilla::VERSION
-                else
-                  "#{Rulezilla::VERSION}.#{ENV['GEM_PRE_RELEASE']}"
-                end
-
   gem.authors       = ['Peter Wu']
   gem.email         = ['peter.wu@simplybusiness.com']
   gem.description   = %q{Rules DSL}
@@ -17,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($\)
   gem.name          = 'rulezilla'
   gem.require_paths = ['lib']
-  gem.version       = gem_version
+  gem.version       = Rulezilla::VERSION
   gem.license       = 'MIT'
 
   gem.add_runtime_dependency('gherkin', '~> 2.5')


### PR DESCRIPTION
upgrade gemstash versioning logic so that dependabot can automatically
manage versions of dependencies in the gemspec

dependabot is used to create automatic PRs for security vulnerabilities