### PR TITLE
Create dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "08:00"
+    open-pull-requests-limit: 99
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "08:00"
+    open-pull-requests-limit: 99


### PR DESCRIPTION
This pull request adds a `dependabot` configuration file to automate dependency updates for both Ruby gems and GitHub Actions. The configuration specifies a daily update schedule with a limit on the number of open pull requests.

Dependency update automation:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R14): Introduced a new configuration file to enable `dependabot` for managing dependencies. It includes daily update schedules at 8:00 AM for both the `bundler` (Ruby gems) and `github-actions` ecosystems, with a limit of 99 open pull requests for each.